### PR TITLE
(typo) Rename PacketKind::HvcC to Hvc1

### DIFF
--- a/src/playback/video.rs
+++ b/src/playback/video.rs
@@ -31,7 +31,7 @@ pub enum PacketKind {
     /// AVC decoder configuration record.
     AvcC,
     /// HEVC decoder configuration record.
-    HvcC,
+    Hvc1,
     /// Regular encoded video payload.
     Payload,
     /// Auxiliary plist payload.

--- a/src/streaming/processing/mod.rs
+++ b/src/streaming/processing/mod.rs
@@ -195,7 +195,7 @@ pub async fn video_processor(
             let kind = match ptr.get_u16_le() {
                 1 => {
                     if payload.len() >= 8 && &payload[4..8] == b"hvc1" {
-                        PacketKind::HvcC
+                        PacketKind::Hvc1
                     } else {
                         PacketKind::AvcC
                     }


### PR DESCRIPTION
hvcC and hvc1 are related, but they are not the same kind of thing.

hvcC is an MP4/ISOBMFF configuration box. It stores HEVC/H.265 decoder setup data such as VPS, SPS, and PPS parameter sets.  ￼

hvc1 is an HEVC sample entry / codec tag used in MP4. It tells players the HEVC track expects its required parameter sets to be provided through the sample description/configuration data, typically the hvcC box, rather than relying on them being inside every video sample.  ￼

In one line: hvc1 identifies the HEVC track format; hvcC contains the decoder configuration for that track.

example of hvc1:
```
offset 0
size: 229
type: hvc1
data_reference_index: 65535
width: 994
height: 2160
horizontal resolution: 72 dpi
vertical resolution: 72 dpi
frame_count: 1
compressor name: HEVC
depth: 24
```

useful data: you can get the width and height